### PR TITLE
Bump boolector-sys to v0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["boolector", "smt", "ffi", "bindings"]
 license = "MIT"
 
 [dependencies]
-boolector-sys = "0.6.1"
+boolector-sys = "0.7.1"
 libc = "0.2.73"
 
 [features]


### PR DESCRIPTION
Hi,

the vendored Boolector build fails with recent GCC 11 versions due to a warning and `-Werror`:
```
In file included from [..]/build/boolector-sys-427e4c8213b0d23c/out/build/googletest/googletest-src/googletest/src/gtest-all.cc:42:
[..]/build/boolector-sys-427e4c8213b0d23c/out/build/googletest/googletest-src/googletest/src/gtest-death-test.cc: In function ‘bool testing::internal::StackGrowsDown()’:
[..]/build/boolector-sys-427e4c8213b0d23c/out/build/googletest/googletest-src/googletest/src/gtest-death-test.cc:1301:24: error: ‘dummy’ may be used uninitialized [-Werror=maybe-uninitialized]
   1301 |   StackLowerThanAddress(&dummy, &result);
        |   ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
[..]/build/boolector-sys-427e4c8213b0d23c/out/build/googletest/googletest-src/googletest/src/gtest-death-test.cc:1290:13: note: by argument 1 of type ‘const void*’ to ‘void testing::internal::StackLowerThanAddress(const void*, bool*)’ declared here
   1290 | static void StackLowerThanAddress(const void* ptr, bool* result) {
        |             ^~~~~~~~~~~~~~~~~~~~~
[..]/build/boolector-sys-427e4c8213b0d23c/out/build/googletest/googletest-src/googletest/src/gtest-death-test.cc:1299:7: note: ‘dummy’ declared here
   1299 |   int dummy;
        |       ^~~~~
  cc1plus: all warnings being treated as errors
build script failed, must exit now', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/cmake-0.1.48/src/lib.rs:975:5
```

Updating `boolector-sys` to `v0.7` works around this with a slightly tweaked build environment which doesn't pass `-Werror` anymore.
The `boolector-sys` upgrade comes with a slight version bump in Boolector from `3.2.1` to `3.2.2`, but this doesn't change the bindings apart from a new `boolector_get_value` API.


(cc @xorpse, I've submitted your patch since it's exactly what I would've committed and it saves a few clicks. I hope this is fine with you ^^)